### PR TITLE
ipython notebooks =>4.0 are dependent on jupyter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ coverage
 html2text
 ipython
 jinja2
+jupyter
 jsonschema
 matplotlib
 networkx


### PR DESCRIPTION
Addition to requirements.txt to ensure that the ipython notebooks start properly