### PR TITLE
Add EME Diversity Analysis notebook

### DIFF
--- a/examples/EME Diversity Analysis.ipynb
+++ b/examples/EME Diversity Analysis.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "_This work was done by [Harsh Gupta](http://hargup.in/) as part of his internship at [The Center for Internet & Society India](http://cis-india.org/)_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import bigbang.mailman as mailman\n",
+    "import bigbang.process as process\n",
+    "from bigbang.archive import Archive\n",
+    "\n",
+    "\n",
+    "import pandas as pd\n",
+    "import datetime\n",
+    "\n",
+    "from commonregex import CommonRegex\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Encrypted Media Extension Diversity Analysis\n",
+    "\n",
+    "[Encrypted Media Extension](https://hsivonen.fi/eme/) (EME) is the controvertial [draft standard at W3C](https://w3c.github.io/encrypted-media/) which aims to aims to prevent copyright infrigement in digital video but opens up door for lots of issues regarding security, accessibility, privacy and interoperability. This notebook tries to analyze if the interests of the important stakeholders were well represented in the debate that happened on `public-html` mailing list of W3C.\n",
+    "\n",
+    "## Methodology\n",
+    "\n",
+    "Any emails with ` EME `, `Encrypted Media` or `Digital Rights Managagement` in the subject line is considered to about EME. Then each of the participant is categorized on the basis of region of the world they belong to and their employeer's interest to the debate. Notes about the participants can be found [here](./people_notes.md).\n",
+    "\n",
+    "### Region Methodology:\n",
+    "\n",
+    "* Look up their personal website and social media accounts (Twitter, LinkedIn,\n",
+    "  Github) and see if it mentions the country they live in. (Works in Most of the cases)\n",
+    "  \n",
+    "* If the person's email has uses a country specific top level domain, assume that as the country\n",
+    "\n",
+    "* If github profile is available look up the timezone on last 5 commits.\n",
+    "\n",
+    "* For people who have moved from their home country consider the country where they live now.\n",
+    "\n",
+    "### Work Methodology\n",
+    "\n",
+    "* Look up their personal website and social media accounts (Twitter, LinkedIn, Github) and see if it mentions the employer and categorize accordingly.\n",
+    "  \n",
+    "* People who work on Accessibility, Privacy or Security but also fit into first three categories are categorized in one of the first three categories. For example someone who works on privacy in Google will be placed in \"DRM platform provider\" instead of \"Privacy\".\n",
+    "\n",
+    "* If no other category can be assigned, then assign \"None of the Above\"\n",
+    "\n",
+    "\n",
+    "### Other Notes\n",
+    "\n",
+    "* Google's position is very interesting, it is DRM provider as a browser manufacturer but also a content provider in Youtube and fair number of Google Employers are against EME due to other concerns. I've categorized Christian as Content provider because he works on Youtube, and I've placed everyone else as DRM provider."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def filter_messages(df, column, keywords):\n",
+    "    filters = []\n",
+    "    for keyword in keywords:\n",
+    "        filters.append(df[column].str.contains(keyword, case=False))\n",
+    "\n",
+    "    return df[reduce(lambda p, q: p | q, filters)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Opening 69 archive files\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/hargup/code/bigbang/bigbang/archive.py:74: FutureWarning: sort(columns=....) is deprecated, use sort_values(by=.....)\n",
+      "  self.data.sort(columns='Date', inplace=True)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get the Archieves\n",
+    "pd.options.display.mpl_style = 'default'  # pandas has a set of preferred graph formatting options\n",
+    "\n",
+    "mlist = mailman.open_list_archives(\"https://lists.w3.org/Archives/Public/public-html/\", archive_dir=\"./archives\") \n",
+    "\n",
+    "# The spaces around eme are **very** important otherwise it can catch things like \"emerging\", \"implement\" etc\n",
+    "eme_messages = filter_messages(mlist, 'Subject', [' EME ', 'Encrypted Media', 'Digital Rights Managagement'])\n",
+    "eme_activites = Archive.get_activity(Archive(eme_messages))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "474.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eme_activites.sum(0).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# XXX: Bugzilla might also contain discussions\n",
+    "eme_activites.drop(\"bugzilla@jessica.w3.org\", axis=1, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Remove Dupicate senders\n",
+    "levdf = process.sorted_matrix(eme_activites)\n",
+    "\n",
+    "consolidates = []\n",
+    "# gather pairs of names which have a distance of less than 10\n",
+    "for col in levdf.columns:\n",
+    "  for index, value in levdf.loc[levdf[col] < 10, col].iteritems():\n",
+    "        if index != col: # the name shouldn't be a pair for itself\n",
+    "            consolidates.append((col, index))\n",
+    "            \n",
+    "# Handpick special cases which aren't covered with string matching\n",
+    "consolidates.extend([(u'Kornel Lesi\\u0144ski <kornel@geekhood.net>',\n",
+    "                      u'wrong string <kornel@geekhood.net>'),\n",
+    "                     (u'Charles McCathie Nevile <chaals@yandex-team.ru>',\n",
+    "                      u'Charles McCathieNevile <chaals@opera.com>')])\n",
+    "\n",
+    "eme_activites = process.consolidate_senders_activity(eme_activites, consolidates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sender_categories = pd.read_csv('people_tag.csv',delimiter=',', encoding=\"utf-8-sig\")\n",
+    "\n",
+    "# match sender using email only\n",
+    "sender_categories['email'] = map(lambda x: CommonRegex(x).emails[0].lower(), sender_categories['name_email'])\n",
+    "\n",
+    "sender_categories.index = sender_categories['email']\n",
+    "cat_dicts = {\n",
+    "    \"region\":{\n",
+    "        1: \"Asia\",\n",
+    "        2: \"Australia and New Zealand\",\n",
+    "        3: \"Europe\",\n",
+    "        4: \"Africa\",\n",
+    "        5: \"North America\",\n",
+    "        6: \"South America\"\n",
+    "    },\n",
+    "    \"work\":{\n",
+    "        1: \"Foss Browser Developer\",\n",
+    "        2: \"Content Provider\",\n",
+    "        3: \"DRM platform provider\",\n",
+    "        4: \"Accessibility\",\n",
+    "        5: \"Security Researcher\",\n",
+    "        6: \"Other W3C Empoyee\",\n",
+    "        7: \"Privacy\",\n",
+    "        8: \"None of the above\"\n",
+    "\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_cat_val_func(cat):\n",
+    "    \"\"\"\n",
+    "    Given category type, returns a function which gives the category value for a sender.\n",
+    "    \"\"\"\n",
+    "    def _get_cat_val(sender):\n",
+    "        try:\n",
+    "            sender_email = CommonRegex(sender).emails[0].lower()\n",
+    "            return cat_dicts[cat][sender_categories.loc[sender_email][cat]]\n",
+    "        except KeyError:\n",
+    "            return \"Unknow\"\n",
+    "    return _get_cat_val"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Emails sent per region\n",
+      "\n",
+      "Australia and New Zealand     16\n",
+      "Europe                       146\n",
+      "North America                310\n",
+      "dtype: float64\n",
+      "Total emails: 472.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "grouped = eme_activites.groupby(get_cat_val_func(\"region\"), axis=1)\n",
+    "print(\"Emails sent per region\\n\")\n",
+    "print(grouped.sum().sum())\n",
+    "print(\"Total emails: %s\" % grouped.sum().sum().sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Participants per region\n",
+      "Europe: 13\n",
+      "North America: 30\n",
+      "Australia and New Zealand: 5\n",
+      "Total participants: 48\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Participants per region\")\n",
+    "for group in grouped.groups:\n",
+    "    print \"%s: %s\" % (group,len(grouped.get_group(group).sum()))\n",
+    "print(\"Total participants: %s\" % len(eme_activites.columns))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Notice that there is absolutely no one from Asia, Africa or South America.**  This is important because the DRM laws, attitude towards IP vary considerably across the world.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Emails sent per work category\n",
+      "Accessibility              47\n",
+      "Content Provider          186\n",
+      "DRM platform provider     100\n",
+      "Foss Browser Developer     56\n",
+      "None of the above          71\n",
+      "Other W3C Empoyee          10\n",
+      "Privacy                     2\n",
+      "dtype: float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "grouped = eme_activites.groupby(get_cat_val_func(\"work\"), axis=1)\n",
+    "print(\"Emails sent per work category\")\n",
+    "print(grouped.sum().sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Participants per work category\n",
+      "Privacy: 2\n",
+      "Foss Browser Developer: 5\n",
+      "Accessibility: 4\n",
+      "Other W3C Empoyee: 3\n",
+      "DRM platform provider: 15\n",
+      "Content Provider: 9\n",
+      "None of the above: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Participants per work category\")\n",
+    "for group in grouped.groups:\n",
+    "    print \"%s: %s\" % (group,len(grouped.get_group(group).sum()))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/people_notes.md
+++ b/examples/people_notes.md
@@ -1,0 +1,276 @@
+* Andreas Kuckartz a.kuckartz@ping.de
+ Germany, based on his email provider
+Unknown
+
+* "appelquist daniel \(uk\)" <daniel.appelquist@telefonica.com>
+ UK
+ Samsung Government Digital Services Open Data Institute, CMU 
+ https://www.linkedin.com/in/dappelquist
+
+* Boris Zbarsky
+ USA
+ Mozilla
+
+
+* "carr, wayne" <wayne.carr@intel.com>
+ USA
+ Intel, not sure if Intel has any special interests found no substantial online profile.
+
+* "jens o. meiert" <jens@meiert.com>
+ Germany
+ Had worked with Google (quit in Aug 2013) and part of WHATWG
+ http://meiert.com/en/biography/
+
+* "john c. vernaleo" <john@netpurgatory.com>
+ USA
+ Company0 and Conformal Systems, none of them appear to have any versted interests
+ https://www.linkedin.com/in/johnvernaleo
+
+* "jukka k. korpela"
+ Finnish
+ works for Elisa Telecom and internet service
+
+* "l. david baron" <dbaron@dbaron.org>
+ USA
+ Works for Mozilla
+
+* "mays, david" <david_mays@comcast.com>
+ USA
+ Comcast
+ https://www.linkedin.com/in/davidmays
+
+* "vickers, mark" <mark_vickers@cable.comcast.com>
+ USA
+ VP software engineering ComCast
+ https://www.linkedin.com/in/mark-vickers-7b455559
+
+* adrian roselli
+ Accessible Platform Architectures Working Group, Federated Social Web Community
+ USA citizen
+
+* adrian bateman <adrianba@microsoft.com>
+ USA
+ Microsoft, of the
+ https://www.linkedin.com/in/adrianba
+
+* andreas kuckartz
+ German
+
+* arthur barstow <art.barstow@nokia.com>
+ USA
+ Nokia worked on standards
+ https://www.linkedin.com/in/artbarstow
+
+* benjamin hawkes-lewis
+ UK
+ Apple (Now) VisualDNA
+
+* bob lund <b.lund@cablelabs.com>
+ USA
+ CableLabs
+ https://www.linkedin.com/in/bob-lund-6b5531
+
+* cameron heavon-jones
+ UK
+ Independent contractor
+ W3C
+
+* charles McCathieNevile
+ Semantic web and accessibility
+ Yandex
+
+* charles Pritchard
+ US, uses 8000 timezone
+ Jumis, which is a web applications and services provider, works on Canvas Accessiblity and have few open source apps
+
+* chris pearce <cpearce@mozilla.com>
+ New Zealand
+ Mozilla
+ https://www.linkedin.com/in/chris-pearce-417243
+
+* christian kaiser <kaiserc@google.com>
+ USA
+ Has has own Machine Intelligence firm but worked for Youtube and before that at NetFlix
+ https://www.linkedin.com/in/christiankaiser
+
+* clarke stevens <c.stevens@cablelabs.com>
+ USA
+ Tech Startegist at CableLabs
+ https://www.linkedin.com/in/j-clarke-stevens-msee-mba-12562
+
+* daniel GLAZMAN
+ French Citizen, CoChair CSS working group, Samsung, Netscape http://www.glazman.org/CV_enDanielGlazman.html
+
+* danny o'brien <danny@eff.org>
+ England
+ Journalist at EFF
+ https://www.eff.org/about/staff/danny-obrien-0
+
+* david dorwin <ddorwin@google.com>
+ USA
+ Google
+ https://www.linkedin.com/in/daviddorwin
+
+* david singer <singer@apple.com>
+ USA
+ Multimedia standards at Apple, He has written on identity management and privacy principles in W3C. https://www.w3.org/2011/track-privacy/papers/Apple.pdf https://www.w3.org/2011/identity-ws/papers/idbrowser2011_submission_51.pdf
+ https://www.linkedin.com/in/dasinger
+
+* duncan bayne <dhgbayne@fastmail.fm>
+ Australia
+ Software developer at Cogent and previously at GreenSync, both of them does't seem to have any special interest in EME debate
+ https://www.linkedin.com/in/duncanbayne
+
+* eric carlson <eric.carlson@apple.com>
+ USA
+ Apple
+ https://www.linkedin.com/in/eric-carlson-672a
+
+* Glenn Adams works
+ USA
+ Cox Communications
+
+* Henri Sivonen
+ Finland
+ Mozilla
+https://twitter.com/hsivonen
+
+* ian devlin
+ Irish
+ works for trivago specializing in hotel search.
+
+* Ian Hickson
+ USA
+ He works for Google and is a part of CSS working group.
+
+* ian jacobs
+ USA
+ Head of W3C payment, from 2004 W3C Marketing and Communications Had done some work on accessibility prior to that.
+
+* jeff jaffe <jeff@w3.org>
+ USA
+ CEO of W3C
+
+* John Foliot
+ USA
+ He is the principal accessibility strategist, for the last 15 year he has worked to make make websites more accessible, prior to that he worked for the record industry for 15 year.
+http://john.foliot.ca/
+
+* john simmons <johnsim@microsoft.com>
+ USA
+ Media Platform Architecht Microsoft
+ https://www.linkedin.com/in/johnsimmons2
+
+* julian reschke
+ German
+ works for GmbH
+
+* kevin streeter <kstreete@adobe.com>
+ USA
+ Works on Video at Adobe
+ https://www.linkedin.com/in/kevinstreeter
+
+* kornel Lesiński
+ UK
+ works at Financial Times
+
+* lachlan hunt <lachlan.hunt@lachy.id.au>
+ Australia
+ Works with NOrigin Media (European firm) from 2013 providing TV and video product, Previously Opera part of WHATWG
+ https://lachy.id.au/about/resume
+
+* laura Carlson
+ Works for University of Minnesota
+ Web accessebility
+ http://webstandardsgroup.org/features/laura-carlson.htm
+
+* leif halvard silli
+ From Norway
+
+* leonard rosenthol <lrosenth@adobe.com>
+ USA
+ Adobe
+ https://www.linkedin.com/in/lrosenthol
+
+* maciej stachowiak 
+ Polish
+ Apple
+ https://en.wikipedia.org/wiki/Maciej_Stachowiak
+
+* manu sporny <msporny@digitalbazaar.com>
+ USA
+ Worked on Digital Payment standards within W3C, but not a W3C employee anymore
+ https://www.linkedin.com/in/manusporny
+
+* marat tanalin
+ Russian
+ works for Yandex
+
+* Mark Watson
+ USA
+ Netflix, director streaming standards
+ https://www.linkedin.com/in/markwatson7
+
+* mathew marquis
+ US citizen
+ developer at Bocoup
+ Open Source Web Development Consulting
+
+* michael\[tm\] smith 
+  Works for W3C was previously in Opera based in Tokyo
+  http://people.w3.org/mike//
+
+* nicholas doty <npdoty@w3.org>
+ USA
+ Privacy Analyst at W3C, Director of Center for Technology, Society and Policy
+ https://www.linkedin.com/in/npdoty
+
+* philip jägenstedt
+ Swedish
+ Opera
+
+* reinier kaper
+ Dutch Web Developer working for website development company
+
+* robert o'callahan <robert@ocallahan.org>
+ New Zealand (http://robert.ocallahan.org/2014/03/mozilla-and-silicon-valley-cartel.html says that he lives in New Zealand) account The timezone in one of this github repo says +1300 and -0700
+ Mozilla, rr developer
+ http://robert.ocallahan.org
+
+* robin Berjon
+ French Australian Bi national
+ Part of Technical Architecture Group
+ Long time member of W3C
+
+* sam Ruby
+ USA
+ Apache Foundation, W3C
+
+* silvia pfeiffer
+ Open Video technologies
+ National ICT Australia
+
+* simon pieters
+ Swedish
+ Opera
+
+* smylers <smylers@stripey.com>
+ UK
+ Independent Developer (little employment information is available)
+ https://github.com/Smylers
+
+* steve faulkner
+ USA
+ Accessibility
+ Paciello group
+ https://github.com/southpolesteve
+
+* Tab Atkins
+ USA
+ Google as a web standard's hacker http://www.xanthir.com
+ http://www.xanthir.com
+
+* イアンフェッティ <ifette@google.com> Ian Fette
+ USA
+ Gwaker CTO, ex Googler worked on privacy and security in chromium
+ https://www.linkedin.com/in/ianfette

--- a/examples/people_tag.csv
+++ b/examples/people_tag.csv
@@ -1,0 +1,63 @@
+name_email,region,work
+"appelquist daniel \(uk\)" <daniel.appelquist@telefonica.com>,3,8
+"carr, wayne" <wayne.carr@intel.com>,5,8
+"jens o. meiert" <jens@meiert.com>,3,3
+"john c. vernaleo" <john@netpurgatory.com>,5,8
+"jukka k. korpela" <jukka.k.korpela@kolumbus.fi>,3,8
+"l. david baron" <dbaron@dbaron.org>,5,1
+"mays, david" <david_mays@comcast.com>,5,2
+"tab atkins jr." <jackalmage@gmail.com>,5,3
+\"marat tanalin | tanalin.com\" <mtanalin@yandex.ru>,3,8
+\"michael\[tm\] smith\" <mike@w3.org>,1,3
+adrian bateman <adrianba@microsoft.com>,5,3
+adrian roselli <roselli@algonquinstudios.com>,5,4
+andreas kuckartz <a.kuckartz@ping.de>,3,8
+arthur barstow <art.barstow@nokia.com>,5,8
+benjamin hawkes-lewis <bhawkeslewis@googlemail.com>,3,3
+bob lund <b.lund@cablelabs.com>,5,2
+boris zbarsky <bzbarsky@mit.edu>,5,1
+cameron heavon-jones <cmhjones@gmail.com>,3,6
+chaals mccathie nevile <chaals@yandex-team.ru>,3,4
+charles pritchard <chuck@jumis.com>,3,4
+chris pearce <cpearce@mozilla.com>,2,1
+christian kaiser <kaiserc@google.com>,5,2
+clarke stevens <c.stevens@cablelabs.com>,5,2
+daniel glazman <daniel.glazman@disruptive-innovations.com>,3,1
+danny o'brien <danny@eff.org>,3,7
+david dorwin <ddorwin@google.com>,5,3
+david singer <singer@apple.com>,5,3
+duncan bayne <dhgbayne@fastmail.fm>,2,8
+edward o'connor <eoconnor@apple.com>,5,3
+eric carlson <eric.carlson@apple.com>,5,3
+glenn adams <glenn@skynav.com>,5,2
+henri sivonen <hsivonen@iki.fi>,3,1
+ian devlin <ian@iandevlin.com>,3,8
+ian hickson <ian@hixie.ch>,5,2
+ian jacobs <ij@w3.org>,5,6
+jeff jaffe <jeff@w3.org>,5,6
+john foliot <john@foliot.ca>,5,4
+john simmons <johnsim@microsoft.com>,5,3
+julian reschke <julian.reschke@gmx.de>,3,8
+kevin streeter <kstreete@adobe.com>,5,3
+kornel lesiński <kornel@geekhood.net>,3,8
+lachlan hunt <lachlan.hunt@lachy.id.au>,2,2
+laura carlson <laura.lee.carlson@gmail.com>,5,4
+leif halvard silli <xn--mlform-iua@xn--mlform-iua.no>,3,8
+leonard rosenthol <lrosenth@adobe.com>,5,3
+maciej stachowiak <mjs@apple.com>,3,3
+manu sporny <msporny@digitalbazaar.com>,5,6
+mark watson <watsonm@netflix.com>,5,2
+mathew marquis <mat@matmarquis.com>,5,1
+nicholas doty <npdoty@w3.org>,5,7
+paul cotton <paul.cotton@microsoft.com>,5,3
+philip jägenstedt <philipj@opera.com>,3,3
+reinier kaper <rp.kaper@gmail.com>,3,6
+robert o'callahan <robert@ocallahan.org>,2,1
+robin berjon <robin@berjon.com>,3,6
+sam ruby <rubys@intertwingly.net>,3,6
+silvia pfeiffer <silviapfeiffer1@gmail.com>,2,8
+simon pieters <simonp@opera.com>,3,3
+smylers <smylers@stripey.com>,3,8
+steve faulkner <faulkner.steve@gmail.com>,5,4
+vickers mark <mark_vickers@cable.comcast.com>,5,2
+イアンフェッティ <ifette@google.com>,5,3


### PR DESCRIPTION
Other than the analysis itself, the notebook illustrates:
* How to filter messages by keywords
* How to categorize messages
* How to calculate aggregate statistics on groups of messages

(Original source https://github.com/hargup/eme_diversity_analysis)